### PR TITLE
Proposal for a "model" construct for SQL, NoSQL, & ORM dialects

### DIFF
--- a/sudolang.sudo.md
+++ b/sudolang.sudo.md
@@ -157,6 +157,53 @@ result = match (value) {
 
 Interfaces are a powerful feature in SudoLang that allow developers to define the structure of their data and logic. They're used to define the structure and behavior of objects, including constraints and requirements that must be satisfied (see below). The `interface` keyword is optional.
 
+## Models
+
+Models are a programming construct for generating database specifications for both relational and non-relational database libraries. The types used in the `model` programming construct resemble the types defined in the SQL specification, but a user can also freely insert requirements, warnings, constraints, and natural language prompts / inferences into the `model` object and have them converted into their syntactical equivalents in the target SQL, NoSQL, or ORM dialect.
+
+```SudoLang
+model User {
+  id: integer;
+  name: string;
+  email: string;
+  password: string;
+  created_at: datetime;
+  updated_at: datetime;
+
+  // Relationships
+  relations {
+    posts: hasMany(Post);
+    profile: hasOne(Profile
+
+);
+    group: belongsTo(Group);
+  }
+
+  // Requirements
+  require {
+    id must be unique;
+    email must be unique;
+  }
+
+  // Constraints
+  constraint {
+    created_at is automatically set to the current date and time when a record is created;
+    updated_at is automatically updated to the current date and time whenever the record is updated;
+  }
+
+  // Procedures
+  procedure {
+    When creating a new user, hash the password before storing it in the database;
+    When updating a user's password, hash the new password before storing it in the database;
+  }
+
+  // Warnings
+  warn {
+    email should be validated before being stored in the database;
+  }
+}
+```
+
 ## Requirements
 
 Requirements enforce rules for interfaces and program behavior. They're great for input validation and rule enforcement.
@@ -328,7 +375,6 @@ interface lint {
     offer tips to take advantage of SudoLang's declarative features, like
       constraints.
   }
-}
 ```
 
 ## SudoLang Interpreter

--- a/sudolang.sudo.md
+++ b/sudolang.sudo.md
@@ -125,7 +125,7 @@ The range operator `..` can be used to create a range of numbers. e.g.:
 
 ### Destructuring
 
-Destrcuturing allows you to assign multiple variables at once by referencing the elements of an array or properties of an object. e.g.:
+Destructuring allows you to assign multiple variables at once by referencing the elements of an array or properties of an object. e.g.:
 
 Arrays:
 
@@ -204,7 +204,7 @@ model User {
 }
 ```
 
-##Seeder Specification
+## Seeders
 
 Seeder scripts are used to populate a database with initial data. In Sudolang, seeder scripts can be defined using the seeder construct. The seeder construct allows you to specify the model to be seeded, the number of instances to be created, and the properties of each instance.
 

--- a/sudolang.sudo.md
+++ b/sudolang.sudo.md
@@ -204,6 +204,72 @@ model User {
 }
 ```
 
+##Seeder Specification
+
+Seeder scripts are used to populate a database with initial data. In Sudolang, seeder scripts can be defined using the seeder construct. The seeder construct allows you to specify the model to be seeded, the number of instances to be created, and the properties of each instance.
+
+
+```SudoLang
+model User {
+  id: integer;
+  name: string;
+  email: string;
+  password: string;
+  created_at: datetime;
+  updated_at: datetime;
+
+  // Relationships
+  relations {
+    posts: hasMany(Post);
+  }
+}
+
+model Post {
+  id: integer;
+  title: string;
+  content: string;
+  user_id: integer; // Foreign key to User model
+  created_at: datetime;
+  updated_at: datetime;
+}
+
+seeder UserAndPostSeeder {
+  run() {
+    createUsersWithPosts(50, 5); // Create 50 users each with 5 posts
+  }
+}
+
+function createUsersWithPosts(numberOfUsers, postsPerUser) {
+  for each i in 1..numberOfUsers {
+    user = User.create({
+      id: i,
+      name: 'User $i',
+      email: 'user$i@example.com',
+      password: 'password',
+      created_at: now(),
+      updated_at: now()
+    });
+
+    for each j in 1..postsPerUser {
+      Post.create({
+        id: (i - 1) * postsPerUser + j,
+        title: 'Post $j of User $i',
+        content: 'This is post $j of User $i',
+        user_id: user.id,
+        created_at: now(),
+        updated_at: now()
+      });
+    }
+  }
+}
+
+run(UserAndPostSeeder);
+```
+
+In this example, the createUsersWithPosts function creates a specified number of users, and for each user, it creates a specified number of posts. The user_id field in the Post model is used to establish a relationship between the Post and User models. Each post is associated with a user through the user_id field.
+
+Again, this is a high-level example and the actual implementation might vary based on the specific database and ORM you are using.
+
 ## Requirements
 
 Requirements enforce rules for interfaces and program behavior. They're great for input validation and rule enforcement.


### PR DESCRIPTION
I've been using ChatGPT to generate both SQL and ORM code using natural language prompts and thought the "model" construct might be a meaningful addition to the Sudolang spec.