### PR TITLE
Add VSCode launch configuration for extension host and fix syntax pattern mistake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,5 +104,6 @@ dist
 .tern-port
 
 # VS Code
-.vscode/
+.vscode/**/*
+!.vscode/launch.json
 .DS_Store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+// A launch configuration that launches the extension inside a new window
+// Use IntelliSense to learn about possible attributes.
+// Hover to view descriptions of existing attributes.
+// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"]
+    }
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,3 @@
-// A launch configuration that launches the extension inside a new window
-// Use IntelliSense to learn about possible attributes.
-// Hover to view descriptions of existing attributes.
-// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
 {
   "version": "0.2.0",
   "configurations": [

--- a/syntaxes/sudolang.tmLanguage.json
+++ b/syntaxes/sudolang.tmLanguage.json
@@ -38,7 +38,7 @@
         },
         {
           "name": "keyword.operator.math.sudolang",
-          "match": "\\b(cap|cup))\\b"
+          "match": "\\b(cap|cup)\\b"
         },
         {
           "name": "keyword.command.sudolang",


### PR DESCRIPTION
Hey! :) I was following the instructions in [Get up and running straight away](https://github.com/paralleldrive/sudolang-llm-support/blob/main/vsc-extension-quickstart.md#get-up-and-running-straight-away), it took me about half a day to figure out to make it work (also because I've been transitioning to use VSCode only since the beginning of this year, so yeah). Turns out:

1. Launch configuration is needed to "Press `F5` to open a new window with your extension loaded.".
2. There's a syntax pattern mistake that makes the syntax highlighter fails to kick-in (actually I asked GPT-4 🤖🔮✨ to spot the mistake for me -> see screenshot).

![gpt-demo cfapps eu12 hana ondemand com_webclient_standalone_ (4) copy](https://github.com/paralleldrive/sudolang-llm-support/assets/4405796/39320efd-edf4-47bb-b2ec-4964a1eae7f3)
---
This PR should fix both. Cheers! 🍻