### PR TITLE
Fix text count and result emoji.

### DIFF
--- a/examples/riteway.sudo
+++ b/examples/riteway.sudo
@@ -85,15 +85,17 @@ function describe(ModuleName, TestFunction) {
 runTests () {
   failedTestsCount = 0;
   passedTestsCount = 0;
-  totalTests = constraint failedTestsCount + passedTestsCount;
-
+  
   for each describe {
     run the test function
   }
 
-  testsPassed = failedTestsCount == 0;
-  emojis = [✅, ❌];
-  log(${ selectEmoji() } ${ totalTests } tests passed, ${ failedTestsCount } failed);
+  totalTestCount = failedTestsCount + passedTestsCount;
+  
+  When all the tests are passed, log("🎉 All tests passed!") and set set resultEmoji to ✅.
+  If there is any failed test case, log("😭 Some tests failed.") and set resultEmoji to ❌.
+  
+  log(${ resultEmoji } ${ totalTestCount } run, ${ passedTestsCount } passed, ${ failedTestsCount } failed);
 }
 
 usage:

--- a/examples/riteway.sudo
+++ b/examples/riteway.sudo
@@ -82,20 +82,21 @@ function describe(ModuleName, TestFunction) {
 
 ## runTests
 
+State {
+  failedTestCount
+  passedTestCount
+  totalTests
+  emojis: [✅, ❌]
+}
+
 runTests () {
-  failedTestsCount = 0;
-  passedTestsCount = 0;
-  
   for each describe {
     run the test function
   }
 
-  totalTestCount = failedTestsCount + passedTestsCount;
-  
-  When all the tests are passed, log("🎉 All tests passed!") and set set resultEmoji to ✅.
-  If there is any failed test case, log("😭 Some tests failed.") and set resultEmoji to ❌.
-  
-  log(${ resultEmoji } ${ totalTestCount } run, ${ passedTestsCount } passed, ${ failedTestsCount } failed);
+  constraint: Limit response to the prescribed output:
+  "$selectEmoji() $totalTests tests passed, $failedTestsCount failed"
+  $resultEmoji $totalTestCount run, $passedTestsCount passed, $failedTestsCount failed";
 }
 
 usage:
@@ -136,7 +137,7 @@ describe("alwaysThrows", {
 
 describe("pythagoreanTriple", {
   interface pythagoreanTriple {
-    // Generate a valid random pythagorean tripple.
+    // Generate a valid randomized pythagorean tripple made up of double-digit numbers.
     function pythagoreanTriple();
     constraints {
       a^2 + b^2 = c^2

--- a/examples/riteway.sudo
+++ b/examples/riteway.sudo
@@ -82,14 +82,12 @@ function describe(ModuleName, TestFunction) {
 
 ## runTests
 
-State {
-  failedTestCount
-  passedTestCount
-  totalTests
-  emojis: [✅, ❌]
-}
-
 runTests () {
+  failedTestCount;
+  passedTestCount;
+  totalTests;
+  emojis = [✅, ❌]
+
   for each describe {
     run the test function
   }


### PR DESCRIPTION
Fix the issue of passed/failed test count.
Fix the emoji in final result log.

Verified with test case:

```
/load

describe("myTest", {
  interface myTest {
    // add two numbers
    function myTest(a,b) {
      return a+b;
    }
  }

  assert({
    should: 5,
    actual: myTest(2,4),
  });
});

describe("myTest", {
  interface myTest {
    // add two numbers
    function myTest(a,b) {
      return a+b;
    }
  }

  assert({
    should: 4,
    actual: myTest(2,2),
  });
});

/run
```