### PR TITLE
Add Mermaid diagrams to SudoLang spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ All sufficiently advanced language models understand it without any special prom
 - **Semantic Pattern Matching**. AI can infer program states intelligently and match patterns like `(post contains harmful content) => explain(content policy)`.
 - **Referential omnipotence.** You do not need to explicitly define most functions. The AI will infer them for you.
 - **Functions and function composition** with the `|>` operator.
+- **Mermaid diagrams** for visualizing complex topics like architecture, flow control, and sequence descriptions.
 
 ## Why SudoLang?
 

--- a/sudolang.sudo.md
+++ b/sudolang.sudo.md
@@ -17,7 +17,7 @@ SudoLang is designed to be understood by LLMs without any special prompting. **A
 - **`/commands`** for defining a chat or programatic interface for your program interactions.
 - **Semantic Pattern Matching**. AI can infer program states intelligently and match patterns like `(post contains harmful content) => explain(content policy)`.
 - **Referential omnipotence.** You do not need to explicitly define most functions. The AI will infer them for you.
-
+- **Mermaid diagrams** for visualizing complex topics like architecture, flow control, and sequence descriptions.
 
 ### Markdown
 
@@ -299,6 +299,20 @@ Example output:
     "raise": 10000
   }
 ]
+```
+
+## Mermaid Diagrams
+
+Mermaid diagrams are a powerful way to visualize complex topics like architecture, flow control, and sequence descriptions. SudoLang supports Mermaid diagrams to help you communicate complex ideas and architectures in your SudoLang programs. To learn how to use Mermaid, see the [Mermaid documentation](https://mermaid.js.org/).
+
+Example:
+
+```mermaid
+graph LR
+    Eggs -->|Ingredients| Oven
+    Flower -->|Ingredients| Oven
+    Sugar -->|Ingredients| Oven
+    Oven -->|Non-linear transformation| Cake
 ```
 
 ## Implicit LLM Capabilities


### PR DESCRIPTION
Fixes #24

Add Mermaid diagram support to SudoLang documentation.

* **sudolang.sudo.md**
  - Add a section on Mermaid diagrams, explaining how to use them within SudoLang programs.
  - Add an example Mermaid diagram to the documentation.

* **README.md**
  - Mention Mermaid diagrams as a feature of SudoLang.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/paralleldrive/sudolang-llm-support/issues/24?shareId=ddaff423-35f8-4185-b017-9e3691795006).