### PR TITLE
Add install script to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "sudolang-llm-support",
       "version": "2.0.0-rc.1",
+      "hasInstallScript": true,
       "devDependencies": {
         "@types/node": "14.x",
         "@types/vscode": "^1.91.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "build": "vsce package"
+    "build": "vsce package",
+    "install": "code --install-extension sudolang-llm-support-*.vsix"
   },
   "contributes": {
     "languages": [


### PR DESCRIPTION
Add an install script to `package.json` to install the VS Code extension using a version-agnostic approach.

* **package.json**
  - Add an install script to the `scripts` section.
  - Use the command `code --install-extension sudolang-llm-support-*.vsix` in the install script.

* **package-lock.json**
  - Add `"hasInstallScript": true` to indicate the presence of an install script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/paralleldrive/sudolang-llm-support?shareId=5c8d83d9-d8cd-47d6-a03c-d338df52ffb6).