### PR TITLE
Deprecate cup and cap operators in favor of union and intersection

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,8 +10,10 @@ import {
     DiagnosticCollection
   } from 'vscode';
   
-  const disallowedKeywords = ['class', 'inherits', 'extends', 'super'];
+  const disallowedKeywords = ['class', 'inherits', 'extends', 'super', 'cap', 'cup'];
   const warningMessage = "Class inheritance is not a recommended code reuse pattern due to the fragile base class and gorilla banana problems. Prefer interfaces, modules, functions, factory functions, or composition to avoid duplication by necessity.";
+  const capWarningMessage = "The keyword 'cap' is deprecated in favor of 'intersection' due to instability in Claude 3.5.";
+  const cupWarningMessage = "The keyword 'cup' is deprecated in favor of 'union' due to instability in Claude 3.5.";
   
   export function activate(context: ExtensionContext) {
     const diagnosticCollection = languages.createDiagnosticCollection('sudolang');
@@ -29,9 +31,15 @@ import {
           while ((startIndex = line.text.indexOf(keyword, startIndex)) >= 0) {
             const range = new Range(lineIndex, startIndex, lineIndex, startIndex + keyword.length);
             if (document.getWordRangeAtPosition(range.start, /\b\w+\b/)?.isEqual(range)) {
+              let message = `The keyword '${keyword}' is discouraged in SudoLang. ${warningMessage}`;
+              if (keyword === 'cap') {
+                message = capWarningMessage;
+              } else if (keyword === 'cup') {
+                message = cupWarningMessage;
+              }
               const diagnostic = new Diagnostic(
                 range,
-                `The keyword '${keyword}' is discouraged in SudoLang. ${warningMessage}`,
+                message,
                 DiagnosticSeverity.Warning
               );
               diagnostics.push(diagnostic);

--- a/sudolang.sudo.md
+++ b/sudolang.sudo.md
@@ -68,7 +68,10 @@ access = if (age >= 18 && isMember) "granted" else "denied"
 
 All common math operators are supported, including the following:
 
-`+`, `-`, `*`, `/`, `^` (exponent), `%` (remainder), `cap` (`∩`) and `cup` (`∪`)
+`+`, `-`, `*`, `/`, `^` (exponent), `%` (remainder), `union` and `intersection`
+
+> Note: The `cup` and `cap` operators are deprecated in favor of `union` and `intersection` due to instability in Claude 3.5.
+
 
 ### Commands
 
@@ -412,3 +415,5 @@ Lint {
   }
 }
 ```
+
+

--- a/syntaxes/syntax-test.sudo
+++ b/syntaxes/syntax-test.sudo
@@ -144,8 +144,11 @@ remainder = 17 % 5
 result = ((10 + 5) * 3 - (20 / 4)) ^ 2 % 7
 
 // Set Operators
-commonFruits = tropicalFruits cap localFruits
-allFruits = tropicalFruits cup localFruits
+commonFruits = tropicalFruits intersection localFruits
+allFruits = tropicalFruits union localFruits
+
+// Note: The `cup` and `cap` operators are deprecated in favor of `union` and `intersection` due to instability in Claude 3.5.
+
 
 // Combining different operators
 finalScore = (baseScore + bonusPoints) * difficultyMultiplier


### PR DESCRIPTION
Fixes #29

Deprecate `cup` and `cap` operators in favor of `union` and `intersection` due to instability in Claude 3.5.

* **CHANGELOG.md**
  - Add a note mentioning that `cup` and `cap` are deprecated in favor of `union` and `intersection`.
  - Mention that the new `union` and `intersection` keywords were tested in GPT-4o, Claude 3.5, and Llama 3.1 with 100% accuracy.

* **src/extension.ts**
  - Update `disallowedKeywords` array to include `cap` and `cup`.
  - Add specific warning messages for `cap` and `cup` operators.
  - Modify diagnostic message logic to include new warning messages for `cap` and `cup`.

* **sudolang.sudo.md**
  - Update math operators section to replace `cap` and `cup` with `union` and `intersection`.
  - Add a note about the deprecation of `cup` and `cap` operators.

* **syntaxes/syntax-test.sudo**
  - Replace `cap` and `cup` operators with `union` and `intersection`.
  - Add a comment mentioning the deprecation of `cup` and `cap` operators.

* **syntaxes/sudolang.tmLanguage.json**
  - Add the new keywords
  - Fix alphabetical order

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/paralleldrive/sudolang-llm-support/issues/29?shareId=c8dd0ac8-3fa4-4f50-9fe6-93dea6a40d70).