### PR TITLE
Enhance SudoLang syntax documentation

### DIFF
--- a/syntaxes/syntax-test.sudo
+++ b/syntaxes/syntax-test.sudo
@@ -8,6 +8,13 @@ A quick cheat sheet for SudoLang syntax.
 
 ## Interfaces
 
+type DateTime = Number(POSIX time, e.g. JS Date.now())
+
+Meta {
+  id: String(cuid2)
+  createdAt: DateTime
+}
+
 DisplayTheme {
   mode: "light" | "dark"
   name: String
@@ -20,7 +27,8 @@ UserPreferences {
 }
 
 User {
-  id: String
+  // spread can be used for interface composition
+  ...meta
   displayName
   preferences
 }
@@ -189,7 +197,7 @@ processedData = rawData |> normalize |> filter |> sort
 
 ## Disallowed Keywords
 
-Should generate a warning for disallowed keywords.
+Should generate a warning for disallowed keywords, e.g. `class`, `extends`, and `super`. Favor composition over inheritance.
 
 class Foo extends Bar {
   constructor() {


### PR DESCRIPTION
Updated SudoLang syntax cheat sheet with interface composition and disallowed keywords clarification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - Introduces `DateTime` type alias and a `Meta` interface (`id`, `createdAt`).
> - Demonstrates interface composition by spreading `...meta` into `User` and annotates usage via comment.
> - Clarifies disallowed keywords with examples (`class`, `extends`, `super`) and recommends composition over inheritance.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a2999d5fc8876ac4a0343b33f2fb8d01c98e683. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->